### PR TITLE
ENG-2526 - Add Agent SDK integration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of AI agent skills for working with [Kapa](https://www.kapa.ai). Th
 | [Analyze Top Questions](#analyze-top-questions) | Work through your most common topics and ensure your documentation covers them well. |
 | [Analyze Source Analytics](#analyze-source-analytics) | Audit your most-cited documentation pages against the questions they were used to answer. |
 | [Answer RFP](#answer-rfp) | Answer incoming RFPs end-to-end using a kapa-powered MCP as the sole knowledge source. |
+| [Agent SDK Integration](#agent-sdk-integration) | Set up, improve, or migrate to the Kapa Agent SDK in your own application. |
 
 ### Analyze Coverage Gaps
 
@@ -43,6 +44,14 @@ Answer incoming RFPs (and vendor questionnaires / security assessments) end-to-e
 2. Connect your kapa MCP server to your Claude session (kapa platform → Integrations → Hosted MCP Server)
 3. Invoke the skill with your AI agent: `/answer-rfp`
 4. Upload the RFP document when prompted and follow the guided workflow
+
+### Agent SDK Integration
+
+Add a Kapa AI agent to your own application with the [Kapa Agent SDK](https://docs.kapa.ai/dev/agent), improve an existing integration, or migrate from the Kapa Chat SDK. The agent works interactively: it explores your codebase, decides whether to use the React or Core SDK, finds the API endpoints that make good agent tools and reasons through which to include with you, drafts custom instructions from your product, sets up server-side session authentication and (optionally) conversation history, and themes the chat to match your app. Nothing is invented: it grounds every detail in the installed package types and the official docs, and confirms each decision with you.
+
+1. Install the skill into your application repository by copying it into your agent's skills directory
+2. Set up an Agent integration in the [Kapa dashboard](https://app.kapa.ai) (Integrations → Agent) so you have a Project ID, Integration ID, and API key ready
+3. Invoke the skill with your AI agent from within your app repository: `/agent-sdk-integration`
 
 ## Compatibility
 

--- a/skills/agent-sdk-integration/SKILL.md
+++ b/skills/agent-sdk-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-sdk-integration
-description: Set up, improve, or migrate to the Kapa Agent SDK (@kapaai/agent-react or @kapaai/agent-core) in a web application. Use when the user wants to add a Kapa AI agent or in-product assistant to their app, turn existing API endpoints into agent tools, review or improve an existing Kapa Agent SDK integration, or migrate from the Kapa Chat SDK (@kapaai/react-sdk) to the Agent SDK. Covers React and non-React apps, tool discovery, custom instructions, tool approval and custom rendering, session-token authentication, and conversation history.
+description: Set up, improve, or migrate to the Kapa Agent SDK (@kapaai/agent-react or @kapaai/agent-core), also referred to as the Kapa Agent Framework, in a web app. Always use this whenever a developer mentions the Kapa Agent SDK, the Kapa Agent Framework, or the packages @kapaai/agent-react or @kapaai/agent-core, however they phrase it. Also use it when they want to embed a Kapa AI agent, in-product assistant, or support chat into their app, turn their API endpoints into agent tools, add Kapa knowledge base search to their own UI, review or improve an existing setup, or migrate from the Kapa Chat SDK (@kapaai/react-sdk), even if they never say "Agent SDK" explicitly. Covers React and non-React apps, tool discovery, custom instructions, approval and custom rendering, session-token auth, and conversation history.
 ---
 
 # Kapa Agent SDK integration

--- a/skills/agent-sdk-integration/SKILL.md
+++ b/skills/agent-sdk-integration/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: agent-sdk-integration
+description: Set up, improve, or migrate to the Kapa Agent SDK (@kapaai/agent-react or @kapaai/agent-core) in a web application. Use when the user wants to add a Kapa AI agent or in-product assistant to their app, turn existing API endpoints into agent tools, review or improve an existing Kapa Agent SDK integration, or migrate from the Kapa Chat SDK (@kapaai/react-sdk) to the Agent SDK. Covers React and non-React apps, tool discovery, custom instructions, tool approval and custom rendering, session-token authentication, and conversation history.
+---
+
+# Kapa Agent SDK integration
+
+Guide a developer through adding the Kapa Agent SDK to their application, improving an existing integration, or migrating from the Kapa Chat SDK. The Agent SDK embeds an AI agent chat that answers from the customer's knowledge base out of the box (built-in server-side knowledge base search) and can call tools that run in the user's browser.
+
+This skill is a collaborative workflow, not a code generator. Propose, explain the trade-offs, and confirm before making changes. The developer knows their product and their users better than you do.
+
+## Golden rules
+
+1. **Work interactively.** At every decision point (which SDK, which tools, approval, history, UI, how the panel opens), present options with a recommendation and a one-line rationale, then let the developer choose. Grouping a few tightly-related quick decisions into one prompt is fine; do not overwhelm with a long chain, and always give concrete defaults.
+2. **Ground every API detail in the source of truth.** The SDK evolves. Do not rely on memory for prop names, tool shapes, or endpoints. Before writing integration code:
+   - **Ground against the version you will actually ship, and prefer the latest.** For a new setup or a migration, install the current release explicitly (`npm install @kapaai/agent-react@latest`, or the repo's package manager). Do this even when a copy already exists in `node_modules`: a pre-existing install can be stale and older than the current release, and grounding against it produces outdated code. After installing, read that version's types. For an existing-setup review, ground against the version the repo already ships, and see the Improve section for when to suggest an upgrade.
+   - **Read the installed package types.** Find each package's type entry from its own `package.json` (the `types` field, or the `types` entries under `exports`). It is commonly `dist/index.d.ts`, `dist/index.d.mts`, or `dist/index.d.cts`, so do not assume a `.d.ts` extension. Read both `@kapaai/agent-react` and `@kapaai/agent-core`.
+   - Consult the official docs at `https://docs.kapa.ai/dev/agent` (fetch them if you have web access). See "Reference links" below.
+   - If the installed types disagree with this skill or the docs, trust the installed types for the version you are shipping. This skill's embedded details track the 1.0.0 API.
+3. **Never invent endpoints, props, or tool APIs.** Only wire up endpoints you have actually found in the codebase. Only pass props that exist in the installed types.
+4. **Never expose the API key to the browser.** Session tokens are minted server-side. See `references/auth-and-history.md`.
+5. **Keep the tool set small and high-signal.** Fewer reliable tools beat a large grab-bag. Start with the essential ones and expand later.
+6. **Make no destructive changes without buy-in.** Show diffs or plans first.
+
+## Reference links (source of truth)
+
+- Overview: `https://docs.kapa.ai/dev/agent`
+- React SDK: `https://docs.kapa.ai/dev/agent/react` and provider props at `https://docs.kapa.ai/dev/agent/react/agent-provider`
+- Core (JS/TS) SDK: `https://docs.kapa.ai/dev/agent/core`
+- Custom tools: `https://docs.kapa.ai/dev/agent/react/custom-tools` and `https://docs.kapa.ai/dev/agent/core/custom-tools`
+- Authentication: `https://docs.kapa.ai/dev/agent/guides/authentication`
+- Theming: `https://docs.kapa.ai/dev/agent/react/theming`
+- Conversation history: `https://docs.kapa.ai/dev/agent/react/conversation-history`
+- Migrating from the Chat SDK: `https://docs.kapa.ai/dev/agent/guides/migrating-from-chat-sdk`
+- Best practices for in-product agents: `https://docs.kapa.ai/dev/agent/guides/best-practices-in-product-agent`
+- Runnable examples: `https://github.com/kapa-ai/agent-sdk-examples`
+
+## Prerequisites and credentials
+
+The integration needs four values: a **Project ID**, an **Integration ID**, the agent **model** id (for example `kapa-agent-1.0`, pin a specific version), and a server-side **API key**. The Project ID and Integration ID come from the Kapa dashboard (Integrations to Agent); the API key from Settings to API Keys.
+
+Confirm these are actually available before writing any code that depends on them:
+
+- Look where the app keeps configuration: `.env`, `.env.local`, `.env.example`, framework env conventions (`VITE_*`, `NEXT_PUBLIC_*`, and similar), the env schema (for example an `env.mjs` or `env.ts` validation file), and any deployment or secret config. Grep for existing related keys (names containing `AGENT` or `KAPA`) and **reuse them**; do not invent new variable names for config the app already defines. Reading the wrong env var name is a silent failure: the provider builds fine but renders nothing.
+- **If a required value or its environment variable is missing, stop and ask the developer for it** (or point them to the dashboard). Do not proceed with placeholder or guessed values: the code will build, but the agent will silently fail at runtime, which is hard to debug.
+- Keep the **API key server-side only** (for example `KAPA_API_KEY`); never put it in a client-exposed variable. When you introduce new env vars, add them to `.env.example` (or the repo's documented env list) with empty values, and never commit real secrets.
+
+## Step 0: Detect the mode and confirm
+
+Inspect the repo, then confirm the mode with the developer:
+
+- **No Kapa SDK present** and the developer wants an agent: **Setup**.
+- **`@kapaai/react-sdk` present** (the Chat SDK) and the developer wants tools or actions: **Migrate**. See `references/migration.md`.
+- **`@kapaai/agent-react` or `@kapaai/agent-core` already present**: **Improve**. Review the existing setup against the checklist at the end and `references/*`, and fix gaps.
+
+Check `package.json` dependencies and search the code for `@kapaai/`.
+
+## Step 1: Explore the codebase
+
+Before recommending anything, build a picture of the app. Do this with searches and by reading a few representative files. Work from the current state of the code: do not mine git history or removed branches for a previous integration to copy, since a prior or deleted setup may be outdated or intentionally gone.
+
+1. **Framework and rendering model.** Read `package.json`. Look for `react`, `next`, `remix`, `vue`, `svelte`, `@angular/core`, `solid-js`, or none. Note TypeScript vs JavaScript. Note bundler (Vite, Next, webpack).
+2. **Where the app mounts its top-level providers** (the root component or layout). The Kapa provider must sit high in the tree and stay mounted.
+3. **The data-access layer and every endpoint.** This is the most important exploration step and it has its own playbook: follow `references/tool-discovery.md`. It shows how to detect TanStack Query / React Query, SWR, axios, fetch wrappers, tRPC, GraphQL, and generated OpenAPI clients, and how to enumerate all endpoints so none are missed.
+4. **Auth model.** How are API calls authenticated (cookies, bearer token, an `apiClient`, an `authFetch` wrapper)? Tools will reuse this. Is there a backend in this repo or a separate one?
+5. **Design system and theming.** Note the color system, fonts, dark/light handling, any component library, and any **icon library** (`@tabler/icons-react`, `lucide-react`, `@heroicons/react`, `react-icons`, and similar) so the agent UI and tool icons can match the app.
+
+Summarize what you found back to the developer before proposing the integration.
+
+## Step 2: Choose the SDK (React vs Core)
+
+Recommend, then confirm:
+
+- **React, Next.js, Remix, or any React-based app: use `@kapaai/agent-react`.** It includes `@kapaai/agent-core` as a dependency. This is true even if the developer wants a fully custom UI: in that case they use the headless `useAgentChat()` hook from `agent-react`, not `agent-core` directly.
+- **Non-React app (Vue, Svelte, Angular, vanilla JS, server, edge): use `@kapaai/agent-core`.** You will build the chat UI to match the app. See `references/ui.md`.
+
+Within React, decide the UI approach (see `references/ui.md`):
+- **Built-in UI** (`AgentChat` or the slide-in `AgentPanel`): fastest, themed, full-featured. Recommend this unless the developer needs deep UI control. If you use `AgentPanel`, ask how they want to open it (a floating action button, a fixed button in the header or nav, a command-menu entry, or other): the trigger is yours to build, not the SDK's. See `references/ui.md`.
+- **Headless** (`AgentProvider` + `useAgentChat()`): full control, they build every element.
+
+## Step 3: Session authentication and (optionally) history
+
+Every integration needs a server-side session endpoint. If the backend is in this repo (or this repo is the backend), scaffold the endpoint for the detected framework. Then decide with the developer whether to enable conversation history, which requires a stable per-user owner id in the session request. Follow `references/auth-and-history.md`.
+
+## Step 4: Design the tools
+
+Using the endpoint inventory from Step 1, decide together which endpoints become tools and why. Design tools around the questions and actions users actually have, not around the API surface. Include discovery/list tools that return IDs so the agent can chain them. Split read-only tools (execute immediately) from write or navigation tools (require approval). Follow `references/tool-discovery.md` for candidate selection and `references/agent-configuration.md` for how to define them, when to require approval, and when to render custom UI.
+
+## Step 5: Draft the custom instructions
+
+Write a `customInstructions` block grounded in what you learned about the product and the tools. It should define domain terms, describe how to chain interdependent tools, and prevent known bad patterns (especially repeating rendered data as text). Follow `references/agent-configuration.md`. Do not write it silently: present the draft to the developer and invite edits before finalizing.
+
+## Step 6: Wire it up and verify
+
+Install the current release of the package (`@latest`; do not rely on whatever is already in `node_modules`, which may be stale), add the provider, add the session endpoint, add tools and instructions, and theme it to match the app. Do not import any CSS from the SDK: its styles load at runtime, and importing a package stylesheet (for example `@kapaai/agent-react/dist/style.css`) breaks the build.
+
+Then verify. Static checks are required; live browser testing is offered, not forced:
+
+1. **Static (required).** Run the project's typecheck, linter, and build. Tools are wired to real endpoints and real app types, so a typecheck catches wrong field names, missing exports, and bad endpoint parameters. Fix everything.
+2. **Live (optional, ask first).** A green build is not proof it works: a wrong env var name or a provider that is not mounted passes the build but shows nothing, so exercising the app in a browser is the real check. Not every agent can drive a browser, and the developer may not want it, so offer it and only do it yourself if you are able and the developer agrees. Either way, hand the developer a short checklist to confirm (verify knowledge-base-only behavior first, before tools): the assistant opens; knowledge base answers stream with no custom tools involved; each chosen tool fires; approval prompts appear for write and navigation tools; custom-rendered tools do not duplicate their data as text; and, if enabled, history lists and resumes.
+
+## Improve mode: audit an existing integration
+
+Read the existing provider setup, tools, and instructions, then check against this list and fix gaps with the developer:
+
+- The installed SDK version is current. Compare the installed version (in `node_modules`/`package.json`) against the latest release (for example `npm view @kapaai/agent-react version`). If it is behind, point it out and offer to upgrade, summarizing what changed and any migration needed, but let the developer decide. Do not upgrade without buy-in.
+- Provider is mounted high and stays mounted (state resets on unmount).
+- `tools` and `context` are stable (memoized in React) so they are not recreated every render.
+- Every write, delete, or navigation tool sets `needsApproval: true`; read-only tools do not.
+- Tool responses are small (return the minimum the agent needs, with a way to drill deeper).
+- Discovery/list tools exist and return IDs for the tools that need them.
+- Custom-rendered tools do not cause the agent to restate their data as text (see the anti-duplication section in `references/agent-configuration.md`).
+- Custom instructions define domain terms and tool-chaining strategy.
+- The API key is never in the browser; the session endpoint is server-side.
+- If history is enabled, the session is created with a stable owner id.
+- Theming matches the host app.
+
+## Final checklist (all modes)
+
+- [ ] Correct SDK chosen and installed at the current release (`agent-react` for React, `agent-core` otherwise; `@latest` for new setups and migrations); `zod` and `zod-to-json-schema` installed if using Zod schemas.
+- [ ] Required credentials and env vars are present (Project ID, Integration ID, model, server-side API key); missing ones were confirmed with the developer, not guessed, and added to `.env.example`.
+- [ ] Server-side session endpoint returns `{ session_token, expires_at }`; API key stays on the server.
+- [ ] Provider configured with `projectId`, `integrationId`, `model`, and `getSessionToken`.
+- [ ] Knowledge base answering verified with zero custom tools.
+- [ ] Tool set is small, high-signal, and agreed with the developer; write and navigation tools require approval.
+- [ ] The built-in `search_knowledge_base` has a friendly display name via `builtinToolMeta`; tools have display names, and icons where the app has an icon library.
+- [ ] `customInstructions` drafted from the codebase and shown to the developer for edits.
+- [ ] Custom rendering (if any) does not duplicate data as text.
+- [ ] History decision made; owner id wired if enabled.
+- [ ] If an active tenant/project/workspace scopes the agent, the conversation resets when it changes (and on logout).
+- [ ] UI matches the app (theme for React, hand-built to match for Core).
+- [ ] Static checks pass (typecheck, lint, build). Live browser behavior checked where possible (by you with the developer's go-ahead, or by the developer following your checklist): KB answer with no tools, each tool fires, approval prompts, history.

--- a/skills/agent-sdk-integration/references/agent-configuration.md
+++ b/skills/agent-sdk-integration/references/agent-configuration.md
@@ -1,0 +1,127 @@
+# Defining tools, approval, custom rendering, and custom instructions
+
+This covers how to turn the chosen endpoints into tools, when to gate them behind approval, when to render custom UI (and how to avoid the common duplication pitfall), and how to draft the custom instructions.
+
+Always confirm prop and type details against the installed package types and `https://docs.kapa.ai/dev/agent`.
+
+## Built-in knowledge base search comes first
+
+Before adding any tool, remember the agent already has a built-in, server-side `search_knowledge_base` tool. It answers product questions from the customer's knowledge sources with cited sources, with no setup. Custom tools are additive on top of that.
+
+**Always give the built-in tool a friendly display name via `builtinToolMeta`.** Without it the chat shows the raw `search_knowledge_base` name, which looks unpolished. Add an `icon` and `iconColor` too when the app has an icon library (see "Display names and icons" below):
+
+```ts
+builtinToolMeta: {
+  search_knowledge_base: {
+    displayName: 'Search docs',
+    icon: SearchIcon,   // optional, if the app has an icon library
+    iconColor: '#38bdf8', // optional
+  },
+}
+```
+
+## Defining a tool
+
+Use `createToolHelper` for type-safe definitions. In React import it from `@kapaai/agent-react`; in non-React from `@kapaai/agent-core`. Zod schemas need `zod` and `zod-to-json-schema` installed.
+
+```tsx
+import { createToolHelper } from '@kapaai/agent-react';
+import { z } from 'zod';
+
+type ToolContext = { apiClient: ApiClient }; // whatever your tools need
+const tool = createToolHelper<ToolContext>();
+
+const tools = [
+  tool({
+    name: 'list_orders',                         // sent to the LLM; snake_case, action-oriented
+    description: 'List the current user\'s orders, most recent first. Returns id and summary per order.',
+    parameters: z.object({
+      status: z.enum(['open', 'shipped', 'all']).optional().describe('Filter by status'),
+      limit: z.number().optional().describe('Max results, default 20'),
+    }),
+    displayName: 'List orders',                  // shown in the UI
+    execute: async ({ status, limit }, ctx) => {
+      return ctx.apiClient.listOrders({ status, limit });   // reuse the app's own API + auth
+    },
+  }),
+];
+```
+
+The `execute` function receives the parsed, typed args and the shared `context` object (whatever you passed to the provider or `Agent`). Put the app's API client, auth token, or fetch wrapper in `context` so tools reuse existing authentication and permission checks.
+
+Guidance:
+
+- **Name and description are prompt surface.** The name is the model's first signal for when to call the tool. The description should say what it does and what it returns. Be concrete.
+- **Keep parameter schemas simple.** Simple schemas produce far more reliable tool calls than complex nested ones. If the model fills a tool inconsistently, simplify the schema before adding more instructions.
+- **Return small results.** See `tool-discovery.md`. Trim and flatten before returning.
+
+## Display names and icons
+
+Give every tool a human-readable `displayName`; it is what the chat shows instead of the raw snake_case name. Set it on the built-in tool too, via `builtinToolMeta` (above).
+
+If the codebase already uses an icon library, set an `icon` (and optional `iconColor`) on each tool and on the built-in tool so the chat matches the app's visual language. Detect the library during exploration; common ones are `@tabler/icons-react`, `lucide-react`, `@heroicons/react`, and `react-icons`. The `icon` prop expects a component that accepts `{ size?, color?, stroke? }` props, so Tabler, Lucide, and Heroicons-style components fit directly. If the app's icons do not match that shape, wrap them in a small adapter or skip the icon rather than passing an incompatible component. Do not add an icon dependency just for this; use only what the app already has. (`icon` and `iconColor` are React-only; in Core you render icons yourself.)
+
+## Approval: read vs write
+
+Set `needsApproval: true` on any tool that changes data, has side effects, or navigates the user. Read-only tools should execute immediately (no approval), or the agent feels sluggish.
+
+- **No approval**: list, get, search, count, analytics. Anything read-only.
+- **Approval required**: create, update, delete, tag, trigger jobs, send messages, and navigation / deep-linking (redirecting the user unexpectedly is jarring).
+
+```tsx
+tool({
+  name: 'cancel_order',
+  description: 'Cancel an order by id.',
+  parameters: z.object({ orderId: z.string() }),
+  needsApproval: true,               // shows Allow / Deny before executing
+  execute: async ({ orderId }, ctx) => ctx.apiClient.cancelOrder(orderId),
+});
+```
+
+With the built-in UI, approval shows Allow / Deny buttons automatically. In headless mode you render them and call `approveToolCall(id)` / `rejectToolCall(id)` from `useAgentChat()` (or the `Agent` methods). Tool status is `approval_requested` until the user decides.
+
+## Custom rendering
+
+By default a tool result renders as an expandable card with JSON. Use the `render` prop (React) when a result is much clearer as a chart, card, table, or other component. This is a React-only feature; in Core you decide how to render tool results in your own UI code.
+
+```tsx
+tool({
+  name: 'get_revenue_series',
+  description: 'Return revenue per period for charting.',
+  parameters: z.object({ period: z.enum(['weekly', 'monthly']) }),
+  execute: async ({ period }, ctx) => ctx.apiClient.revenueSeries(period),
+  render: ({ status, result }) => {
+    if (status !== 'completed') return null;    // fall back to the default card while running
+    return <RevenueChart data={result as Series} />;
+  },
+});
+```
+
+`render` receives `{ status, args, result, error, onApprove, onReject }`. Returning `null` for a status falls back to the default card, so you can customize only the states you care about (for example, keep the default approval UI and only customize the completed state).
+
+Keep the chart or card **schema simple**. A tool with a small, flat data shape (for example a `title`, a `type`, and an array of `{ label, value }`) renders reliably. A tool with a large nested config that mixes data and styling tends to be filled inconsistently by the model.
+
+## The custom-render duplication pitfall (important)
+
+When a tool renders its own UI (a chart, a card), the model will often **also restate the same data as text**, so the user sees the chart and then a paragraph listing every number. This is the single most common polish problem. Defend against it in two complementary ways:
+
+1. **Instruct the model.** Add a rule to `customInstructions`, for example: "After a tool renders its own visual output (a chart or card), do not repeat the underlying numbers in prose. Give only a one-line takeaway or a next step."
+2. **Shape the tool response.** Return a result that signals the UI is already shown rather than dumping the full dataset back into the conversation. For example, return a small object like `{ displayed: true, note: 'Chart shown to the user.' }` (plus any minimal summary the model genuinely needs to reason further), instead of returning the whole series again as text.
+
+Verify this live: ask something that triggers the rendered tool and confirm the model does not echo the data as text underneath.
+
+## Drafting the custom instructions
+
+`customInstructions` is injected into the system prompt and is the single biggest quality lever. Draft it from what you learned about the product and the tools, then review it with the developer. Keep every line earning its place; add a line because you observed a specific failure, not speculatively.
+
+Structure it in sections:
+
+1. **Role and domain context.** One or two sentences on what the product is and what the agent helps with. Then define the domain terms the agent will encounter (drawn from the app's models, types, and UI labels) so it does not misuse them.
+2. **Tool strategy, especially chaining.** Describe how tools combine for common tasks. This is where interdependencies from `tool-discovery.md` go. Typical patterns:
+   - "To filter by a named entity, first call the relevant list tool to resolve the name to an id, then pass the id to the filtering tool."
+   - "For how-many questions, use the count tool rather than listing and counting."
+   - "Prefer short keyword search terms over full sentences" (if the search endpoint expects that).
+3. **Anti-patterns to prevent.** The duplication rule above. Any "never state X as exact when the result is capped" rules. Anything you saw the agent get wrong.
+4. **Optional reinforcement of grounding.** The built-in search already makes the agent cite sources and express uncertainty when the knowledge base lacks an answer. You usually do not need to restate this, but you may reinforce tone if the developer wants.
+
+Draft, then walk through it with the developer line by line. Iterate against real questions.

--- a/skills/agent-sdk-integration/references/auth-and-history.md
+++ b/skills/agent-sdk-integration/references/auth-and-history.md
@@ -1,0 +1,113 @@
+# Session authentication and conversation history
+
+The SDK runs in the browser and talks to the Kapa API using short-lived **session tokens**. Your server mints a token from your API key; the SDK uses the token for all its calls and refreshes it automatically. The API key never reaches the browser.
+
+Confirm the exact endpoint and payload shape against `https://docs.kapa.ai/dev/agent/guides/authentication`.
+
+## The flow
+
+1. The browser calls your own endpoint (for example `POST /api/session`).
+2. Your server calls the Kapa session API with the `X-API-Key` header.
+3. Kapa returns `{ session_token, expires_at }` (token valid for about an hour).
+4. Your server forwards that response to the browser.
+5. The SDK caches the token, refreshes it before expiry, and retries once on a 401.
+
+Kapa session endpoint:
+
+```
+POST https://api.kapa.ai/agent/v1/projects/{projectId}/agent/sessions/
+Header: X-API-Key: <your server-side API key>
+```
+
+## The frontend side
+
+`getSessionToken` points at your endpoint, not at Kapa directly:
+
+```ts
+getSessionToken={async () => {
+  const res = await fetch('/api/session', { method: 'POST' });
+  if (!res.ok) throw new Error('Session creation failed');
+  return res.json(); // raw { session_token, expires_at }; see the TypeScript note below
+}}
+```
+
+At runtime the SDK accepts either the raw Kapa response `{ session_token, expires_at }` or the normalized `{ token, expiresAt }` (where `expiresAt` is a number). Under TypeScript the two packages type this differently: the core `Agent` accepts either shape, but the React `AgentProvider`'s `getSessionToken` prop is typed to return `{ token, expiresAt }`. So in a React plus TypeScript app, either map the response to that shape (for example `{ token: r.session_token, expiresAt: Date.parse(r.expires_at) }`) or return the raw shape with a cast. In plain JavaScript, returning `res.json()` as-is works. The SDK calls `getSessionToken` lazily on the first message, caches the token, and refreshes it about 30 seconds before expiry.
+
+## The backend side: scaffold the endpoint
+
+If the backend is in this repo (or this repo is the backend), create the endpoint for the detected framework. It must keep the API key in a server-side environment variable (for example `KAPA_API_KEY`) and the project id server-side too (for example `KAPA_PROJECT_ID`). If those env vars are not already defined in the repo, ask the developer for the values (or point them to the dashboard), add the keys to `.env.example`, and do not leave the code referencing variables that are never set. Below are minimal, framework-appropriate shapes. Adapt them to the repo's conventions (error handling, auth middleware, logging).
+
+**Next.js App Router** (`app/api/session/route.ts`):
+
+```ts
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const res = await fetch(
+    `https://api.kapa.ai/agent/v1/projects/${process.env.KAPA_PROJECT_ID}/agent/sessions/`,
+    { method: 'POST', headers: { 'X-API-Key': process.env.KAPA_API_KEY! } },
+  );
+  if (!res.ok) return NextResponse.json({ error: 'Session failed' }, { status: res.status });
+  return NextResponse.json(await res.json());
+}
+```
+
+**Express**:
+
+```js
+app.post('/api/session', async (req, res) => {
+  const r = await fetch(
+    `https://api.kapa.ai/agent/v1/projects/${process.env.KAPA_PROJECT_ID}/agent/sessions/`,
+    { method: 'POST', headers: { 'X-API-Key': process.env.KAPA_API_KEY } },
+  );
+  if (!r.ok) return res.status(r.status).json({ error: 'Session failed' });
+  res.json(await r.json());
+});
+```
+
+**Other backends (Django, FastAPI, Rails, Go, etc.)**: same three moves. Read `KAPA_API_KEY` and `KAPA_PROJECT_ID` from server config, `POST` to the Kapa session URL with the `X-API-Key` header, forward the JSON response to the client. Reuse the app's existing auth so only signed-in users can mint a session.
+
+### When the frontend talks to a separate backend
+
+Many frontends (especially SPAs) have no server of their own but call a separate backend through an authenticated fetch or API client. In that case:
+
+- **Reuse the app's existing authenticated request layer** (the `authFetch`, `apiClient`, or cookie/session mechanism you found during exploration) to call the session endpoint, so only signed-in users can mint a token and you do not build a second auth path.
+- **The session-minting endpoint lives on that backend, not in the frontend. Find the real route; do not guess it.** If the backend is a repo in the same workspace, read its URL routing and the session view to confirm the exact path, its path parameters, and how it derives `external_owner_id`. Do not blind-probe URLs with curl; read the source. Inventing a path (wrong prefix or wrong id) builds fine and then returns 404 at runtime.
+- If that backend does not yet expose a session-mint endpoint, it must be added there (server-side, holding the API key and stamping `external_owner_id`). The frontend cannot mint tokens itself.
+- Watch the project-id semantics: the id in the endpoint URL may be a permission gate (a project the signed-in user can access) that is distinct from the Kapa **agent** project id passed to the provider. Confirm which is which from the backend rather than assuming they are the same.
+
+If there is genuinely no backend at all, tell the developer they need one small server endpoint (they cannot mint tokens from the browser) and give them the shape above for their stack.
+
+## Conversation history
+
+History lets users see and resume past conversations. It is **off by default** and has two requirements:
+
+1. Set `enableHistory: true` on the provider (React) or in the `Agent` options (Core).
+2. Create the session with a stable **owner id** so Kapa knows which user owns the threads.
+
+Decide with the developer:
+
+- **Enable it** when users are signed in, will return, and benefit from resuming past chats.
+- **Skip it** for anonymous or one-off usage. Chat still works fully without history.
+
+### Wiring the owner id (required for history)
+
+The owner id is passed as `external_owner_id` in the **body** of the session request, set by your trusted backend. It must be stable for the same user across sessions (for example an internal user id or a hashed email). The browser never sets it, so a user cannot forge another user's history.
+
+```ts
+// server side, inside your session endpoint
+body: JSON.stringify({ external_owner_id: currentUser.id }),
+// remember to send 'Content-Type': 'application/json'
+```
+
+Then the built-in `AgentChat` shows a history toggle automatically. In headless or Core usage, call the history methods from `useAgentChat()` or the `Agent`:
+
+- `listThreads(options?)` returns `{ threads, nextCursor }`.
+- `resumeThread(threadId)` loads a past conversation into the current chat.
+- `deleteThread(threadId)` soft-deletes a thread.
+
+Sessions created without `external_owner_id` can still chat, but the history methods throw `SessionWithoutOwnerError`. Calling history methods when `enableHistory` is off throws `HistoryDisabledError`. A missing or foreign thread id throws `ThreadNotFoundError`. Import these from `@kapaai/agent-core`.
+
+### Verifying history
+
+Create a session with the owner id, have two conversations, reload, and confirm they appear in the list and resume correctly. Confirm a session created without the owner id does not expose another user's threads.

--- a/skills/agent-sdk-integration/references/migration.md
+++ b/skills/agent-sdk-integration/references/migration.md
@@ -1,0 +1,81 @@
+# Migrating from the Chat SDK to the Agent SDK
+
+This covers moving an app from the Kapa Chat SDK (`@kapaai/react-sdk`, provider `KapaProvider`, hook `useChat`) to the Agent SDK (`@kapaai/agent-react`, provider `AgentProvider`, hook `useAgentChat`). The knowledge base answering carries over unchanged; the upgrade adds tools, actions, and approval.
+
+Full mapping and the latest details: `https://docs.kapa.ai/dev/agent/guides/migrating-from-chat-sdk`. Follow it as the source of truth.
+
+## First: keep the existing UI, augment it
+
+The aim is continuity. Do not throw away the current experience. Preserve the app's existing look and behavior, then layer the agent's new abilities (tools, approval) on top. Ask the developer which path they want:
+
+- **Adopt the built-in Agent SDK UI** (`AgentChat` / `AgentPanel`). Less code to maintain, gains theming and tool cards for free. Good when their current UI is close to a standard chat.
+- **Keep their custom UI** and migrate the logic. In React this means using `agent-react`'s headless `useAgentChat()` hook in place of the Chat SDK's `useChat()`. They keep their own components and swap the hook underneath. (Direct `@kapaai/agent-core` is only for non-React apps; a React app keeping a custom UI still installs `agent-react` and uses its hook.)
+
+Recommend based on how custom their current UI is, then let them choose.
+
+## Install
+
+```bash
+npm uninstall @kapaai/react-sdk
+npm install @kapaai/agent-react@latest
+# if you will use Zod tool schemas:
+npm install zod zod-to-json-schema
+```
+
+## Provider: KapaProvider to AgentProvider
+
+The biggest change is authentication. The Chat SDK handled auth internally (integration id plus captcha). The Agent SDK requires a server-side session endpoint and a `getSessionToken` function. Set that up first (see `auth-and-history.md`).
+
+Prop mapping:
+
+- `integrationId` stays; add required `projectId`, `model`, and `getSessionToken`.
+- `customizationId` (server-side prompt) becomes `customInstructions` (injected into the system prompt).
+- `sourceGroupIDsInclude` becomes `sourceGroupIdsInclude` (note the casing change).
+- User identity moves to the `user` prop (`{ email?, unique_client_id? }`).
+- Bot protection (reCAPTCHA / hCaptcha) and `uncertainAnswerCallout` are gone; session-token auth replaces captcha, and the Agent SDK does not expose an uncertainty flag.
+
+## Hook: useChat to useAgentChat
+
+- `submitQuery(query)` becomes `sendMessage(text)` (returns a `Promise<void>`).
+- `isPreparingAnswer` / `isGeneratingAnswer` collapse into a single `isStreaming` boolean (true from the moment `sendMessage` is called until the loop finishes; use it to disable the input and show a stop button).
+- `resetConversation` and `stopGeneration` map directly.
+- `threadId` maps directly.
+- `addFeedback` (thumbs up/down) has no equivalent and is not planned. Build it against your own endpoint if needed.
+- `error` is not a top-level field. Errors surface as assistant messages with `isError: true`, and via the `onEvent` callback with `type: 'response_error'`.
+
+## Conversation model: `conversation` (QA pairs) to `messages` (flat array)
+
+This is the largest structural change.
+
+- `conversation` (a class of question/answer pairs) becomes `messages`, a flat array of `{ role: 'user' | 'assistant', content, ... }`.
+- Assistant messages add a `blocks` array (interleaved `text` and `tool_calls`). Render blocks in order (recommended) so tool calls appear inline. For the simplest migration you can still render `message.content` as one markdown string, closest to the old `qa.answer`.
+- No per-message `id`: use the array index as the React key (messages are append-only). No per-message `status` (use `isStreaming` plus position). No `is_uncertain`, no `reaction`.
+
+## Sources: per-QA to per-tool-call
+
+Sources previously lived on each QA. Now they live on the `search_knowledge_base` tool call results inside an assistant message's `blocks`. Collect them by walking the `tool_calls` blocks and flattening each tool call's `sources`. Field names change: `source_url` becomes `sourceUrl`, `source_type` becomes `sourceType`.
+
+## Callbacks: `callbacks` prop to `onEvent`
+
+The Chat SDK's `callbacks.askAI.*` become a single `onEvent` handler on `AgentProvider` that switches on `event.type`: `message_sent`, `response_completed`, `response_error`, `generation_stopped`, `tool_executed`, `tool_approved`, `tool_denied`, `conversation_reset`. There is no feedback event (feedback is unsupported).
+
+## New capabilities to introduce after the swap
+
+Once the app compiles and chats again with parity, add what the Agent SDK unlocks. Do this incrementally, with the developer:
+
+- **Tools**: follow `tool-discovery.md` and `agent-configuration.md`.
+- **Approval** for write and navigation tools.
+- **Custom instructions** grounded in the product.
+- **Custom rendering** where a result is clearer as a component (mind the duplication pitfall).
+- **Theming** to match the app, and **history** if users are signed in.
+
+## Migration checklist
+
+- [ ] `@kapaai/react-sdk` removed, `@kapaai/agent-react` installed (plus `zod` + `zod-to-json-schema` if using Zod).
+- [ ] Server-side session endpoint added; `getSessionToken` wired; API key server-only.
+- [ ] Provider swapped with `projectId`, `integrationId`, `model`; props remapped.
+- [ ] Hook usage swapped; streaming, stop, reset, and errors handled.
+- [ ] Rendering updated to the `messages` / `blocks` model; sources read from tool calls.
+- [ ] Callbacks moved to `onEvent`.
+- [ ] Parity confirmed against the old experience before adding tools.
+- [ ] New capabilities (tools, approval, instructions, theming, history) added incrementally.

--- a/skills/agent-sdk-integration/references/tool-discovery.md
+++ b/skills/agent-sdk-integration/references/tool-discovery.md
@@ -1,0 +1,86 @@
+# Tool discovery: find every endpoint, then pick the right tools
+
+Tools are functions the agent can call. In the Agent SDK they run client-side, so they can reuse the app's existing API calls, auth, and permission checks. The goal of this phase is twofold: find **all** the endpoints the app already talks to, then decide **with the developer** which ones become tools and why.
+
+## Part 1: Find every endpoint
+
+Do not guess the data layer. Detect it, then enumerate exhaustively. Apps usually use one or two of these patterns. Search for all of them.
+
+### Detect the data-access layer
+
+Search the codebase for these signals and note which are present:
+
+- **TanStack Query / React Query**: `@tanstack/react-query`, `react-query`, `useQuery(`, `useMutation(`, `useInfiniteQuery(`, `queryFn`, `queryKey`, `QueryClient`. The `queryFn` bodies and `mutationFn` bodies are where the real HTTP calls live.
+- **SWR**: `swr`, `useSWR(`, `useSWRMutation(`, and the fetcher functions passed to them.
+- **axios**: `axios`, `axios.create(`, `.get(` / `.post(` / `.put(` / `.patch(` / `.delete(`, and any `apiClient` / `http` instance built on it.
+- **fetch wrappers**: a project-local helper such as `apiFetch`, `authFetch`, `request`, `httpClient`, `api.ts`, `client.ts`. Grep for `fetch(` and for the wrapper name.
+- **tRPC**: `@trpc/`, `createTRPCReact`, `trpc.<router>.<procedure>.useQuery`, and the server router definitions (the routers are the endpoint list).
+- **GraphQL**: `graphql`, `useQuery`/`useMutation` from Apollo or urql, `.graphql` files, or generated hooks. The operations and the schema list the fields.
+- **Generated API clients**: `openapi-typescript`, `openapi-fetch`, `orval`, `swagger-typescript-api`, `@hey-api/openapi-ts`, GraphQL codegen. These generate a typed client whose methods are the full endpoint list. Find the generated file and read its exported methods.
+- **Server routes (if the backend is in this repo)**: Next.js route handlers under `app/api/**/route.ts` or `pages/api/**`, Express/Fastify routers, Django `urls.py` + viewsets, FastAPI routers, Rails routes. These are the authoritative endpoint list for the backend.
+
+### Enumerate exhaustively
+
+Once you know the layer, list every endpoint. Useful tactics:
+
+- Read the central API client or generated client and list its methods.
+- Collect all `queryKey`s / query hooks: each usually maps to one read endpoint.
+- Collect all mutations: each maps to one write endpoint.
+- Grep for the API base URL or path prefix (for example `/api/`, `/v1/`, an env var like `API_URL`) to catch calls that bypass the central client.
+- If there is an OpenAPI or GraphQL schema, read it. It is the complete list.
+
+### Build an endpoint inventory
+
+Produce a table you can discuss with the developer. Do not skip this. Example shape:
+
+| Endpoint / method | What it does | Read or write | Typical latency | Auth / scope | Maps to a user question or action? |
+|---|---|---|---|---|---|
+| `GET /projects` | List projects | read | fast | user token | "what projects do I have" |
+| `POST /projects` | Create a project | write | fast | user token | "create a project" |
+| `GET /reports/export` | Heavy CSV export | read | slow (>5s) | user token | rarely asked directly |
+
+Fill it from what you actually found. Flag anything slow, destructive, admin-only, or paginated.
+
+## Part 2: Choose which endpoints become tools
+
+Design tools around what users ask and want to do, not around the raw API surface. Walk the inventory with the developer and decide each one. Recommend, give a reason, and let them decide.
+
+### Strong candidates (lean toward including)
+
+- **Reads that answer real questions**: status, details, lists, counts, recent activity, analytics.
+- **Discovery / list tools that return IDs.** These resolve human names ("the marketing project") to the IDs other tools need as filters. They are the glue that lets the agent chain calls. Prefer list tools that return both the human-readable name and the ID.
+- **Counts.** A dedicated "how many" tool that returns just a number is cheaper than fetching a list and counting.
+- **Actions users would delegate**: create, update, tag, trigger. Include these only behind approval (see `agent-configuration.md`).
+
+### Weak candidates (lean toward excluding, at least at first)
+
+- **Slow endpoints** (more than a few seconds). A tool that hangs mid-conversation makes the whole agent feel broken. Exclude until the endpoint is faster, and say so.
+- **Endpoints that return huge or deeply nested payloads.** Either exclude, or add a lightweight/summary mode (see below) before including.
+- **Rarely-needed, admin-only, or highly sensitive** operations.
+- **Anything destructive without a clear user need.**
+- **Near-duplicates.** Pick the one that best matches how users ask.
+
+### Reason about the set as a whole
+
+- Prefer a small set of fast, reliable tools that compose well over a comprehensive set. Starting with roughly ten to fifteen and expanding based on usage is usually better than shipping everything.
+- Make sure the discovery tools that other tools depend on are included. A filter tool that needs an ID is useless without the list tool that produces it.
+- Note interdependencies now; they feed directly into the custom instructions (which tool to call first).
+
+### Prepare endpoints for agent consumption
+
+Existing endpoints are often not agent-ready. Common fixes to propose:
+
+- **Lightweight modes**: add a flag (for example `include_details=false`) that returns summaries instead of full nested objects.
+- **Direct lookups**: if an endpoint only returns "the latest" with pagination, a by-key or by-date variant lets the agent fetch a specific item directly.
+- **Counting**: a count-only mode (page size 1, return the total) for "how many" questions.
+- **Small page sizes** by default so the agent does not request thousands of rows.
+- **Selective fields**: strip fields the agent does not need before returning from the tool.
+
+Keep tool responses small. Large responses fill the context window, degrade reasoning, and raise cost. Return the minimum the agent needs, with a way to drill deeper.
+
+## Output of this phase
+
+- An endpoint inventory table.
+- An agreed list of tools to build, each with a one-line reason for inclusion or exclusion.
+- A note of which tools depend on which (for the custom instructions).
+- A list of endpoint adaptations to make (lightweight modes, counts, by-key lookups).

--- a/skills/agent-sdk-integration/references/ui.md
+++ b/skills/agent-sdk-integration/references/ui.md
@@ -1,0 +1,111 @@
+# Building the UI
+
+How to mount the agent and render the chat, for both React (`@kapaai/agent-react`) and non-React (`@kapaai/agent-core`) apps. Match prop and export names against the installed types and `https://docs.kapa.ai/dev/agent`.
+
+**Do not import any CSS from the SDK.** The React SDK injects its own styles at runtime, so no stylesheet import is needed. The package does ship a `dist/style.css`, but it is not exposed through the package `exports` map (only the root entry is), so importing it (for example `import '@kapaai/agent-react/dist/style.css'`) does not resolve and breaks the build. Just mount `AgentProvider` and the styles apply automatically.
+
+## Shared rule: mount the provider high and keep it mounted
+
+The provider (React `AgentProvider`, or the Core `Agent` instance) holds all conversation state: messages, streaming status, session token, approval state. Mount it high in the tree and keep it mounted for the app's lifetime. Unmounting it resets everything. Show and hide the chat by toggling the panel's `open` prop or conditionally rendering the chat component, not by unmounting the provider.
+
+In React, also keep `tools` and `context` **stable** with `useMemo` so they are not recreated on every render. Recreating them churns the agent's configuration and can cause tools to see stale values.
+
+**Reset the agent when the app's active scope changes.** If the agent is scoped to a tenant, project, workspace, or user (for example its tools and its session token are minted for the currently selected project), then a stale conversation and a session from the old scope will leak when the user switches. Watch that scope and call `resetConversation()` when it changes. In React this is a small effect keyed on the scope id that calls `resetConversation` from `useAgentChat()`. Reset on logout too.
+
+## React: built-in UI (recommended default)
+
+Fastest path, fully themed, handles streaming, markdown, tool cards, approval, sources, and history.
+
+```tsx
+import { AgentProvider, AgentChat } from '@kapaai/agent-react';
+
+const tools = useMemo(() => buildTools(), []);
+const context = useMemo(() => ({ apiClient }), [apiClient]);
+
+<AgentProvider
+  getSessionToken={getSessionToken}
+  projectId="your-project-id"
+  integrationId="your-integration-id"
+  model="kapa-agent-1.0"
+  tools={tools}
+  context={context}
+  customInstructions={instructions}
+  theme={{ accentColor: '#2563eb', colorScheme: 'auto' }}
+  enableHistory={false}
+>
+  <div style={{ height: '100vh' }}>
+    <AgentChat branding={{ title: 'AI Assistant', examplePrompts: ['How do I get started?'] }} />
+  </div>
+</AgentProvider>
+```
+
+- `AgentChat` fills its parent container, so give the parent a defined height.
+- For a slide-in drawer instead, use `AgentPanel`, which you control with an `open` / `onClose` pair (add a `top` offset if the app has a fixed navbar). Toggling `open` preserves state.
+  - **The SDK does not provide the button that opens the panel; you build it.** First check whether the app already has an assistant, "Ask AI", or help entry point; if so, wire that to open the panel instead of adding a duplicate trigger. Otherwise this is a visible, product-shaping choice, so ask the developer how they want to trigger it and place it accordingly. Common options: a floating action button (fixed corner, always visible), a fixed button in the existing header or nav bar, an entry in a sidebar or command menu, or a keyboard shortcut. Match the app's existing patterns, and wire the trigger to set the state that drives `AgentPanel`'s `open` prop.
+- For advanced layouts, lower-level components are exported (`AgentInput`, `AgentMessageBubble`, `ToolCallCard`, `SourceTiles`, `ExamplePrompts`, `AgentThreadHistory`). Use only if needed.
+- If the app has an analytics tool (PostHog, Segment, and similar), pass an `onEvent` handler to `AgentProvider` to forward agent events (message sent, tool executed, errors, and so on) for observability, using whatever analytics client the app already uses.
+
+## React: headless (full UI control)
+
+Use `AgentProvider` for state plus the `useAgentChat()` hook, and build every element yourself. This is still the `agent-react` package, not `agent-core`.
+
+```tsx
+import { AgentProvider, useAgentChat } from '@kapaai/agent-react';
+
+function Chat() {
+  const {
+    messages, isStreaming, inputValue, setInputValue,
+    sendMessage, stopGeneration, approveToolCall, rejectToolCall,
+  } = useAgentChat();
+  // render messages (see message model below), an input, and tool cards with Allow/Deny
+}
+```
+
+You render: user bubbles, assistant text, tool call cards (name, status, result, sources), approval buttons, and a streaming indicator. Use a markdown renderer for assistant text and sanitize the output (for example `marked` plus `DOMPurify`).
+
+## Non-React: the Core SDK, build a UI that matches the app
+
+For Vue, Svelte, Angular, vanilla JS, or any non-React app, use `@kapaai/agent-core` directly and render into the app's own components so the chat looks native.
+
+```js
+import { Agent } from '@kapaai/agent-core';
+
+const agent = new Agent({
+  projectId: 'your-project-id',
+  integrationId: 'your-integration-id',
+  model: 'kapa-agent-1.0',
+  tools: [],
+  context: {},
+  getSessionToken,
+  onMessagesChange: (messages) => renderMessages(messages), // wire to reactive state
+  onStreamingChange: (isStreaming) => toggleIndicator(isStreaming),
+});
+
+await agent.sendMessage('How do I get started?');
+```
+
+Methods: `sendMessage`, `stopGeneration`, `resetConversation`, `approveToolCall(id)`, `rejectToolCall(id)`, plus history methods when enabled. Wire `onMessagesChange` and `onStreamingChange` to the framework's reactive state (a Vue `ref`, a Svelte store, an Angular signal or subject).
+
+Build the UI to match the host app: reuse its typography, colors, spacing, buttons, and dark/light handling rather than inventing a new look. Render assistant text as sanitized markdown.
+
+### Message model (both Core and headless React)
+
+Assistant messages carry `blocks`, an ordered array of `text` and `tool_calls` segments. Render blocks in order so text and tool cards interleave the way the agent produced them.
+
+```ts
+type ContentBlock =
+  | { type: 'text'; content: string }
+  | { type: 'tool_calls'; toolCalls: ToolCallDisplay[] };
+```
+
+Each `ToolCallDisplay` has `name`, `displayName`, `status`, `arguments`, `result`, `error`, `durationMs`, and `sources`. Statuses: `pending`, `approval_requested`, `executing`, `completed`, `error`, `denied`, `stopped`. Show Allow / Deny when `status === 'approval_requested'`. Show `sources` (each has `title`, `sourceUrl`, `sourceType`, `sourceVisibility`) as citation links or tiles.
+
+## Theming to match the app
+
+React exposes a `theme` prop on `AgentProvider`:
+
+- `accentColor` (hex; a full palette is generated). **Always set this from the app's primary/brand color token; do not ship only `colorScheme`.** The SDK auto-contrasts foreground text against it.
+- `colorScheme`: `'dark' | 'light' | 'auto'`. Use `'auto'` to follow system, or drive it from the app's own theme toggle via `useAgentColorScheme()`.
+- `fontFamily`, `fontSize`, `radius` (`'sharp' | 'soft' | 'round' | 'pill'`). Match the app's font and corner style.
+
+Pull these values from the app's existing design tokens or theme config rather than hardcoding, so the agent stays visually consistent as the app's theme changes. In Core apps there is no `theme` prop; you achieve consistency by building the UI with the app's own components and tokens.


### PR DESCRIPTION
Adds a new skill, `agent-sdk-integration`, that helps a developer add the Kapa Agent SDK to their own app. It handles three cases: a fresh setup, improving an existing setup, or migrating from the Chat SDK.

The skill runs as a guided, interactive workflow rather than a one-shot generator. It:

- Explores the codebase and decides whether to use the React or Core SDK
- Finds the app's existing API endpoints and works out with the developer which ones make good agent tools
- Sets up server-side session auth (including the case where the app talks to a separate backend) and keeps the API key off the browser
- Drafts a custom instructions block from the app's own domain and tools
- Decides approval, custom rendering, history, theming, and how the panel opens, always confirming with the developer
- Names the built-in knowledge base search tool and reuses the app's icon library
- Verifies with a typecheck/build (required) and offers a live browser check (optional)

It grounds every API detail in the installed package types and the docs, and installs the latest package version so it does not build against a stale copy. Details live in `references/` (tool discovery, agent config, auth and history, UI, migration), loaded as needed.